### PR TITLE
Revert "Update ghcr.io/kashalls/external-dns-unifi-webhook Docker tag to v0.5.1"

### DIFF
--- a/apps/networking/dns/external-dns/values.yaml
+++ b/apps/networking/dns/external-dns/values.yaml
@@ -5,7 +5,7 @@ provider:
   webhook:
     image:
       repository: ghcr.io/kashalls/external-dns-unifi-webhook
-      tag: v0.5.1@sha256:fc031337a83e3a7d5f3407c931373455fe6842e085b47e4bb1e73708cb054b06
+      tag: v0.5.0@sha256:ba9fd69f477f9fb1a4bf6559cc8c405ccd604ad0937f22917612b6c168c1693f
     env:
       - name: UNIFI_HOST
         value: https://192.168.0.1


### PR DESCRIPTION
Reverts jdmcmahan/home-ops#1239